### PR TITLE
feat(quotes): add quotes endpoint api

### DIFF
--- a/src/schwab_client/config.py
+++ b/src/schwab_client/config.py
@@ -83,6 +83,7 @@ class Settings:
     schwab_token_url: str
     schwab_market_data_path: str
 
+
 def load_settings() -> Settings:
     """Load runtime settings."""
 
@@ -108,9 +109,7 @@ def load_settings() -> Settings:
         schwab_token_url=os.getenv(
             "SCHWAB_TOKEN_URL", "https://api.schwabapi.com/v1/oauth/token"
         ),
-        schwab_market_data_path=os.getenv(
-            "SCHWAB_MARKET_DATA_PATH", "/marketdata/v1"
-        )
+        schwab_market_data_path=os.getenv("SCHWAB_MARKET_DATA_PATH", "/marketdata/v1"),
     )
 
 

--- a/src/schwab_client/quotes/quotes.py
+++ b/src/schwab_client/quotes/quotes.py
@@ -1,7 +1,7 @@
-"""Module for interacting with the Schwab Options endpoint."""
+"""Module for interacting with the Schwab quotes endpoint."""
 
 from enum import Enum
-from typing import Union
+from typing import Any, Iterable, Optional, Union
 from urllib.parse import quote
 
 from httpx import Response
@@ -15,6 +15,7 @@ from schwab_client.config import settings
 
 # Define market data path
 MARKET_DATA_PATH = settings.schwab_market_data_path
+
 
 class QuoteFields(str, Enum):
     """Quote field types."""
@@ -32,15 +33,16 @@ class Quotes:
     def __init__(self, client: ClientProtocol) -> None:
         """Quotes init method."""
         self.client = client
-        pass
-   
+
     async def get_quotes(
-        self, tickers: Union[str, list[str]], fields: list[str | Enum] = None
+        self,
+        tickers: Union[str, list[str]],
+        fields: Optional[Iterable[Union[str, Enum]]] = None,
     ) -> Response:
         """Get quote for the provided ticker symbols of symbols.
 
         Args:
-            tickers (str or list[str]: Single or list of ticker symbols.
+            tickers (str or list[str]): Single or list of ticker symbols.
             fields (list(str | Enum)): Request subsets of data. By default, none will return all.
 
         Returns:
@@ -56,25 +58,25 @@ class Quotes:
             <Response [200]>
 
         """
-        params = {}
+        params: dict[str, Any] = {}  # Initialize parameters
 
         # Check fields first
-        fields = validate_enums_iterable(fields, QuoteFields)
+        validated_fields = validate_enums_iterable(QuoteFields, fields)
         if fields:
-            params["fields"] = ",".join(fields)
+            params["fields"] = ",".join(validated_fields)
 
         # Check whether single ticker was given and use proper endpoint
         if isinstance(tickers, str):
-            ticker = normalize_ticker(tickers)
+            ticker_normalized = normalize_ticker(tickers)
             # Encode ticker so / is not reated as a subpath
-            ticker_encoded = quote(ticker, safe="")
+            ticker_encoded = quote(ticker_normalized, safe="")
             path = MARKET_DATA_PATH + "/{}/quotes".format(ticker_encoded)
         # Check whether list of tickers was given and use proper endpoint
         elif isinstance(tickers, list):
-            tickers = [normalize_ticker(t) for t in tickers]
-            params["symbols"] = tickers
+            tickers_normalized = [normalize_ticker(t) for t in tickers]
+            params["symbols"] = tickers_normalized
             path = MARKET_DATA_PATH + "/quotes"
         else:
             raise TypeError(f"{tickers} must be either str or list of str.")
-            
+
         return await self.client._get(path, params)

--- a/src/schwab_client/utils.py
+++ b/src/schwab_client/utils.py
@@ -18,18 +18,19 @@ class OAuth2Token(TypedDict, total=False):
     token_type: str
     scope: str
 
+
 def normalize_ticker(ticker: str) -> str:
     """Normalize a ticker and validate its format.
 
     Args:
         ticker (str): Company publicly listed ticker symbol.
-    
+
     Returns:
         str: Noramlized ticker in all caps.
 
     Raises:
         ValueError: If ticker contains invalid characters.
-    
+
     """
     normalized = ticker.upper()
     # if not normalized.isalnum():
@@ -40,6 +41,7 @@ def normalize_ticker(ticker: str) -> str:
             "Only alphanumeric, dot, slash, space, $, - or _ are allowed."
         )
     return normalized
+
 
 def check_enum_value(field: Union[str, Enum], enum_cls: Type[Enum]) -> str:
     """Return the enum value based on string or Enum member.
@@ -68,9 +70,10 @@ def check_enum_value(field: Union[str, Enum], enum_cls: Type[Enum]) -> str:
         f"'{field}' is neither a string nor a member of {enum_cls.__name__}."
     )
 
+
 def validate_enums_iterable(
-    iterable: Optional[Iterable[Union[str, Enum]]],
-    enum_cls: Type[Enum]
+    enum_cls: Type[Enum],
+    iterable: Optional[Iterable[Union[str, Enum]]] = None,
 ) -> list[str]:
     """Validate that provided values are part of an enum class.
 
@@ -83,7 +86,7 @@ def validate_enums_iterable(
 
     Raises:
         ValueError: If any element is not a valid enum value/member.
-        
+
     """
     if iterable is None:
         return []


### PR DESCRIPTION
Adds the initial release of the quotes endpoint with a polymorphic get_quotes method which can handle both single or multiple tickers per the Schwab ""/{}/quotes" and "/quotes respectively.